### PR TITLE
Remove unnecesary if

### DIFF
--- a/src/main/java/com/cangvel/utils/analysers/PdfFileContentAnalyser.java
+++ b/src/main/java/com/cangvel/utils/analysers/PdfFileContentAnalyser.java
@@ -103,8 +103,7 @@ public class PdfFileContentAnalyser implements FileContentAnalyser {
     }
 
     private void validateFile(File file) throws FileExtensionNotSupportedException {
-        if (allowedExtensions != null)
-            checkForCorrectExtension(file.getName());
+        checkForCorrectExtension(file.getName());
     }
 
     private void checkForCorrectExtension(String filename) throws FileExtensionNotSupportedException {


### PR DESCRIPTION
Allowed file extensions are validated upon constructor so I think double-checking it here is not neccesary